### PR TITLE
zuul: Include full branch name in override-checkout

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -7,13 +7,12 @@
     vars:
       phosh_archive_deploy_url: http://yocto-cache.yocto-build.svc.cluster.local/deploy/
       phosh_archive_deploy_dir: /mnt/cache/yocto/deploy
+    override-checkout: refs/heads/zuul
     required-projects:
-      - name: poky
-        override-checkout: master
-      - name: meta-openembedded
-        override-checkout: master
-      - name: JPEWdev/meta-phosh
-        override-checkout: main
+      - name: git.yoctoproject.org/poky
+        override-checkout: refs/heads/master
+      - name: git.openembedded.org/meta-openembedded
+        override-checkout: refs/heads/master
     nodeset:
       nodes:
         - name: phosh-build-node

--- a/.zuul.d/pipelines.yaml
+++ b/.zuul.d/pipelines.yaml
@@ -1,8 +1,8 @@
 - project:
-    check:
-      jobs:
-        - phosh-qemux86-64
-        - phosh-raspberrypi4-64
+  #    check:
+  #      jobs:
+  #        - phosh-qemux86-64
+  #        - phosh-raspberrypi4-64
 
     gate:
       jobs:


### PR DESCRIPTION
Includes the full branch name; also don't include an override-checkout
for meta-phosh itself since it should be implied from the current branch