### PR TITLE
zuul: Change zstd archive extension

### DIFF
--- a/playbooks/publish-artifact.yaml
+++ b/playbooks/publish-artifact.yaml
@@ -1,7 +1,7 @@
 - name: Download artifact
   get_url:
     url: "{{ item.url }}"
-    dest: "{{ zuul.project.src_dir }}/{{ item.job }}-deploy.tar.zstd"
+    dest: "{{ zuul.project.src_dir }}/{{ item.job }}-deploy.tar.zst"
     checksum: "sha1:{{ item.metadata.sha1 }}"
   retries: 3
   delay: 10
@@ -16,13 +16,13 @@
 
 - name: Publish file
   ansible.builtin.copy:
-    src: "{{ zuul.project.src_dir }}/{{ item.job }}-deploy.tar.zstd"
-    dest: "{{ publish_base_dir }}/{{ item.job }}/{{ item.job }}-deploy.tar.zstd"
+    src: "{{ zuul.project.src_dir }}/{{ item.job }}-deploy.tar.zst"
+    dest: "{{ publish_base_dir }}/{{ item.job }}/{{ item.job }}-deploy.tar.zst"
     remote_src: yes
     unsafe_writes: no
 
 - name: Write checksum file
   ansible.builtin.copy:
-    dest: "{{ publish_base_dir }}/{{ item.job }}/{{ item.job }}-deploy.tar.zstd.sha1sum"
+    dest: "{{ publish_base_dir }}/{{ item.job }}/{{ item.job }}-deploy.tar.zst.sha1sum"
     content: |
-      {{ item.metadata.sha1 }}  {{ item.job }}-deploy.tar.zstd
+      {{ item.metadata.sha1 }}  {{ item.job }}-deploy.tar.zst

--- a/roles/phosh-archive-deploy/defaults/main.yaml
+++ b/roles/phosh-archive-deploy/defaults/main.yaml
@@ -1,3 +1,3 @@
 zuul_work_dir: "{{ zuul.project.src_dir }}"
 phosh_build_dir: "{{ zuul_work_dir }}/build"
-phosh_deploy_filename: "deploy.tar.zstd"
+phosh_deploy_filename: "deploy.tar.zst"


### PR DESCRIPTION
zst is the standard extension and is recognized by many programs, as
opposed to zstd

Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>