### PR TITLE
phosh-publish-daily: Restrict to master branch

### DIFF
--- a/zuul.d/jobs.yaml
+++ b/zuul.d/jobs.yaml
@@ -72,6 +72,7 @@
 
 - job:
     name: phosh-publish-daily
+    branches: master
     run:
       - playbooks/publish-daily.yaml
     dependencies:


### PR DESCRIPTION
We only want builds to be published for specific branches, not all of
them

Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>